### PR TITLE
Add support for checking license headers and fix generated sources jar

### DIFF
--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/build.gradle.kts
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/build.gradle.kts
@@ -5,7 +5,8 @@ object Plugins {
     const val ANDROID_GRADLE_PLUGIN_VERSION = "8.2.0"
     const val KOTLIN_GRADLE_PLUGIN_VERSION = "1.8.20"
     const val SPOTLESS_GRADLE_PLUGIN_VERSION = "6.12.0"
-    const val DOKKA_GRADLE_PLUGIN_VERSION = "1.7.10"
+    const val DOKKA_GRADLE_PLUGIN_VERSION = "1.9.10"
+    const val LICENSE_GRADLE_PLUGIN_VERSION = "0.16.1"
 }
 
 plugins {
@@ -19,6 +20,9 @@ repositories {
     gradlePluginPortal()
     google()
     mavenCentral()
+    maven {
+        url = uri("https://plugins.gradle.org/m2/")
+    }
 }
 
 dependencies {
@@ -26,6 +30,7 @@ dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:${Plugins.SPOTLESS_GRADLE_PLUGIN_VERSION}")
     implementation("com.android.tools.build:gradle:${Plugins.ANDROID_GRADLE_PLUGIN_VERSION}")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:${Plugins.DOKKA_GRADLE_PLUGIN_VERSION}")
+    implementation("gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:${Plugins.LICENSE_GRADLE_PLUGIN_VERSION}")
 }
 
 gradlePlugin {
@@ -33,6 +38,10 @@ gradlePlugin {
         register("AEPLibraryPlugin") {
             id = "aep-library"
             implementationClass = "com.adobe.marketing.mobile.gradle.AEPLibraryPlugin"
+        }
+        register("AEPLicensePlugin") {
+            id = "aep-license"
+            implementationClass = "com.adobe.marketing.mobile.gradle.AEPLicensePlugin"
         }
     }
 }

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLibraryPlugin.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLibraryPlugin.kt
@@ -167,13 +167,6 @@ class AEPLibraryPlugin : Plugin<Project> {
                 targetSdk = BuildConstants.Versions.TARGET_SDK_VERSION
             }
         }
-
-
-        //This task generates a JAR file containing source to be bundled with the AAR.
-        project.sourcesJar.configure {
-            archiveClassifier.set("sources")
-            from(project.tasks.named(BuildConstants.Tasks.PHONE_RELEASE_SOURCES_JAR))
-        }
     }
 
     private fun configureKotlin(project: Project) {

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLicensePlugin.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLicensePlugin.kt
@@ -1,0 +1,63 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+import com.hierynomus.gradle.license.tasks.LicenseFormat
+import nl.javadude.gradle.plugins.license.LicenseExtension
+import org.gradle.kotlin.dsl.get
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import java.util.Calendar
+
+class AEPLicensePlugin: Plugin<Project> {
+    override fun apply(project: Project) {
+        project.plugins.apply(BuildConstants.Plugins.HIERYNOMUS_LICESNE)
+
+        val license = project.extensions.getByType(LicenseExtension::class.java)
+        license.apply {
+            header = project.resources.text.fromString(BuildConstants.ADOBE_LICENSE_HEADER_RESOURCES).asFile()
+            // This plugin does not understand kts extension
+            mapping(mapOf("kts" to "SLASHSTAR_STYLE"))
+            extraProperties.set("year", Calendar.getInstance().get(Calendar.YEAR))
+            skipExistingHeaders = true
+        }
+
+        // Add and maintain licence header to all project files of type XML, YAML, Properties, and Gradle
+        project.tasks.register(BuildConstants.Tasks.LICENSE_FORMAT_PROJECT, LicenseFormat::class.java).configure {
+            // Todo:- Add additional safeguards. This assumes that the parent directory of project.rootDir is the parent directory of our project.
+            source = project.fileTree(project.rootDir.parentFile)
+            exclude(
+                BuildConstants.Path.IDEA_DIR,
+                BuildConstants.Path.BUILD_DIR,
+                BuildConstants.Path.GIT_DIR,
+                BuildConstants.Path.GRADLE_DIR,
+                BuildConstants.Path.GRADLE_WRAPPER_DIR,
+                BuildConstants.Path.LOCAL_PROPERTY_FILES,
+
+                // These files are formatted using spotless
+                BuildConstants.Path.JAVA_FILES,
+                BuildConstants.Path.KOTLIN_FILES,
+            )
+            include(
+                BuildConstants.Path.XML_FILES,
+                BuildConstants.Path.YML_FILES,
+                BuildConstants.Path.PROPERTY_FILES,
+                BuildConstants.Path.GRADLE_KOTLIN_FILES,
+            )
+        }
+
+        project.tasks[BuildConstants.Tasks.LICENSE_FORMAT].dependsOn(BuildConstants.Tasks.LICENSE_FORMAT_PROJECT)
+        project.tasks[BuildConstants.Tasks.LICENSE_FORMAT_PROJECT].group = project.tasks[BuildConstants.Tasks.LICENSE_FORMAT].group
+    }
+}

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/BuildConstants.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/BuildConstants.kt
@@ -109,6 +109,7 @@ object BuildConstants {
         const val CHECKSTYLE = "checkstyle"
         const val MAVEN_PUBLISH = "maven-publish"
         const val SIGNING = "signing"
+        const val HIERYNOMUS_LICESNE = "com.github.hierynomus.license"
     }
 
 
@@ -129,6 +130,9 @@ object BuildConstants {
         const val CREATE_PHONE_DEBUG_COVERAGE_REPORT = "createPhoneDebugCoverageReport"
         const val UNIT_TEST_COVERAGE_REPORT = "unitTestCoverageReport"
         const val TEST_PHONE_DEBUG_UNIT_TEST = "testPhoneDebugUnitTest"
+
+        const val LICENSE_FORMAT_PROJECT = "licenseFormatProject"
+        const val LICENSE_FORMAT = "licenseFormat"
     }
 
     internal object ProjectConfig {
@@ -170,6 +174,16 @@ object BuildConstants {
 
 """
 
+    const val ADOBE_LICENSE_HEADER_RESOURCES = """Copyright ${'$'}{year} Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+"""
     internal object CheckStyle {
         const val CONFIG = """<?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
@@ -264,9 +278,20 @@ object BuildConstants {
         const val INTERNAL_PACKAGES = "**/internal/*"
         const val SRC = "src"
         const val JAVA_FILES = "**/*.java"
+        const val KOTLIN_FILES = "**/*.kt"
         const val GEN_FILES = "**/gen/**"
         const val TEST_FILES = "**/test/**"
         const val LEGACY_FILES = "**/legacy/**"
         const val ANDROID_TEST_FILES = "**/androidTest/**"
+        const val PROPERTY_FILES = "**/*.properties"
+        const val LOCAL_PROPERTY_FILES = "**/local.properties"
+        const val XML_FILES = "**/*.xml"
+        const val YML_FILES = "**/*.yml"
+        const val GRADLE_KOTLIN_FILES = "**/*.gradle.kts"
+        const val IDEA_DIR = "**/.idea/*"
+        const val GIT_DIR = "**/.git/*"
+        const val GRADLE_DIR = "**/.gradle/*"
+        const val GRADLE_WRAPPER_DIR = "**/gradle/wrapper/*"
+        const val BUILD_DIR = "**/build/*"
     }
 }

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/ProjectExtensions.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/ProjectExtensions.kt
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.gradle
 
 import com.android.build.gradle.BaseExtension
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.create
@@ -66,13 +67,9 @@ internal val Project.javadocJar: TaskProvider<Jar>
 /**
  * Retrieves the Source Jar task for the project.
  */
-internal val Project.sourcesJar: TaskProvider<Jar>
+internal val Project.sourcesJar: Task?
     get() {
-        return if (tasks.findByName(BuildConstants.Tasks.SOURCES_JAR) != null) {
-            tasks.named<Jar>(BuildConstants.Tasks.SOURCES_JAR)
-        } else {
-            tasks.register<Jar>(BuildConstants.Tasks.SOURCES_JAR)
-        }
+        return project.tasks[BuildConstants.Tasks.PHONE_RELEASE_SOURCES_JAR]
     }
 
 /**


### PR DESCRIPTION
- Fix source jar generation. 
- Add a plugin for updating license headers across the repository. This requires adding the plugin reference to your root build.gradle.kts file with the line: 
```kotlin
apply(plugin = "aep-license").
```

