### PR TITLE
Minor fixes in AEP Gradle plugin

### DIFF
--- a/android/aepsdk-gradle-plugin/README.md
+++ b/android/aepsdk-gradle-plugin/README.md
@@ -1,0 +1,115 @@
+# AEPSDK Gradle Plugin
+
+## Overview
+This Gradle plugin is designed to simplify the process of configuring and publishing Adobe AEP Android extensions. It streamlines tasks such as generating the POM file, managing dependencies, and configuring various build settings. 
+
+> [!WARNING]
+> This plugin is only intended for Adobe extensions and is not be suitable for general use.
+
+## Usage
+
+### Add JitPack repository
+
+To get started, include the JitPack repository in your project's root `build.gradle.kts` file:
+```kotlin
+// Project's root build.gradle.kts
+
+buildscript {
+    repositories {
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+### Add Plugin dependency
+
+Next, replace `x.x.x` with the appropriate version or commit in the following code snippet within your project's root `build.gradle.kts` file:
+```kotlin
+// Project's root build.gradle.kts
+
+buildscript {
+    dependencies {
+        classpath("com.github.adobe:aepsdk-commons:x.x.x")
+    }
+}
+```
+
+### Apply the plugin
+
+Apply the plugin in your module's `build.gradle.kts` file:
+
+```kotlin
+// Module's build.gradle.kts
+
+plugins {
+    id("aep-library")
+}
+```
+
+### Plugin Configuration
+
+You can configure the plugin for your extension using the `aepLibrary` DSL. 
+
+```
+aepLibrary {
+    // Name of the module associated with your project. 
+    // If absent, it searches in Gradle properties and fails if not provided (required)
+    moduleName = "your_module_name"
+
+    // Version of the module associated with your project. 
+    // If absent, it searches in Gradle properties and fails if not provided (required)
+    moduleVersion = "your_module_version"
+
+    // Namespace for configuring Android library (required)
+    namespace = "your_namespace_here"
+
+    // Indicates whether the library uses Jetpack Compose (optional, default: false)
+    compose = false
+
+    // Indicates whether DokkaDocs should be enabled (optional, default: false)
+    enableDokkaDoc = false
+
+    // Enables Spotless for linting (optional, default: false)
+    enableSpotless = false
+
+    // Configures Spotless to use Prettier for formatting Java code (optional, default: false)
+    enableSpotlessPrettierForJava = false
+
+    // Enables Checkstyle (optional, default: false)
+    enableCheckStyle = false
+
+    // Disables adding common build dependencies (optional, default: false)
+    disableCommonDependencies = false
+
+    // Publishing settings
+    publishing {
+        // Git repository name associated with your project (required)
+        gitRepoName = "your_git_repo_name_here"
+
+        // Maven repository name associated with your project. 
+        // If absent, it searches in Gradle properties and fails if not provided (required)
+        mavenRepoName = "your_maven_repo_name"
+
+        // Maven repository description associated with your project. 
+        // If absent, it searches in Gradle properties and fails if not provided (required)
+        mavenRepoDescription = "your_maven_repo_description"
+
+        // Adds Maven dependency
+        addMavenDependency("your_group_id_here", "your_artifact_id_here", "your_version_here")
+
+        // Helpers for common AEP dependencies
+
+        // Adds Core extension as dependency
+        addCoreDependency("your_version_here")
+
+        // Adds Identity extension as dependency
+        addIdentityDependency("your_version_here")
+
+        // Adds Edge extension as dependency
+        addEdgeDependency("your_version_here")
+
+        // Adds EdgeIdentity extension as dependency
+        addEdgeIdentityDependency("your_version_here")
+    }
+}
+```

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/build.gradle.kts
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/build.gradle.kts
@@ -1,11 +1,11 @@
 
-val PLUGIN_VERSION = "0.0.1"
+val PLUGIN_VERSION = "3.0.0-beta"
 
 object Plugins {
     const val ANDROID_GRADLE_PLUGIN_VERSION = "8.2.0"
     const val KOTLIN_GRADLE_PLUGIN_VERSION = "1.8.20"
     const val SPOTLESS_GRADLE_PLUGIN_VERSION = "6.12.0"
-    const val DOKKA_GRADLE_PLUGIN_VERSION = "1.7.10"
+    const val DOKKA_GRADLE_PLUGIN_VERSION = "1.9.10"
     const val LICENSE_GRADLE_PLUGIN_VERSION = "0.16.1"
 }
 

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/build.gradle.kts
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 
-val PLUGIN_VERSION = "3.0.0-beta"
+val PLUGIN_VERSION = "3.0.0-beta.1"
 
 object Plugins {
     const val ANDROID_GRADLE_PLUGIN_VERSION = "8.2.0"

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLibraryPlugin.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLibraryPlugin.kt
@@ -212,6 +212,7 @@ class AEPLibraryPlugin : Plugin<Project> {
         val dokkaJavadoc = project.tasks.named<DokkaTask>(BuildConstants.Tasks.DOKKA_JAVADOC)
         dokkaJavadoc.configure {
             dokkaSourceSets.named(BuildConstants.SourceSets.MAIN) {
+                jdkVersion.set(8)
                 noAndroidSdkLink.set(false)
                 perPackageOption {
                     matchingRegex.set(".*\\.internal.*") // proper setting
@@ -220,6 +221,8 @@ class AEPLibraryPlugin : Plugin<Project> {
             }
 
             dokkaSourceSets.named(BuildConstants.SourceSets.PHONE) {
+                dependsOn(BuildConstants.SourceSets.MAIN)
+                jdkVersion.set(8)
                 noAndroidSdkLink.set(false)
                 perPackageOption {
                     matchingRegex.set(".*\\.internal.*") // proper setting

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/BuildConstants.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/BuildConstants.kt
@@ -49,7 +49,8 @@ object BuildConstants {
 
         const val ANDROIDX_APPCOMPAT = "1.0.0"
         const val ANDROIDX_CORE_KTX = "1.3.2"
-        const val DOKKA = "1.7.10"
+        const val ANDROIDX_LIFECYCLE_KTX = "2.3.1"
+        const val DOKKA = "1.9.10"
         const val SPOTLESS = "6.12.0"
         const val JUNIT = "4.13.2"
         const val MOCKITO = "4.5.1"
@@ -69,6 +70,7 @@ object BuildConstants {
         const val ANDROIDX_APPCOMPAT = "androidx.appcompat:appcompat:${Versions.ANDROIDX_APPCOMPAT}"
         const val KOTLIN_STDLIB_JDK8 = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.KOTLIN}"
         const val ANDROIDX_CORE_KTX = "androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX}"
+        const val ANDROIDX_LIFECYCLE_KTX = "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_KTX}"
 
         // Test Dependencies
         const val JUNIT = "junit:junit:${Versions.JUNIT}"
@@ -140,7 +142,7 @@ object BuildConstants {
         const val DEBUG_IMPLEMENTATION = "debugImplementation"
         const val TEST_IMPLEMENTATION = "testImplementation"
         const val ANDROID_TEST_IMPLEMENTATION = "androidTestImplementation"
-        const val DOKKA = "dokkaGfmPlugin"
+        const val DOKKA = "dokkaPlugin"
     }
 
     internal object Formatting {

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/JacocoPlugin.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/JacocoPlugin.kt
@@ -14,7 +14,10 @@ package com.adobe.marketing.mobile.gradle
 import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.configure
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.gradle.testing.jacoco.tasks.JacocoReport
 
 
@@ -71,6 +74,13 @@ internal class JacocoPlugin : Plugin<Project> {
                     )
                 )
             )
+        }
+
+        project.tasks.withType(Test::class.java) {
+            this.extensions.configure(JacocoTaskExtension::class.java) {
+                isIncludeNoLocationClasses = true
+                excludes = listOf("jdk.internal.*")
+            }
         }
     }
 }


### PR DESCRIPTION
- Update plugin version to 3.0.0-beta to match the Android major version
- Update Dokkadoc to `1.9.10` and fix doc generation. 
- Expose `androidx.lifecycle:lifecycle-runtime-ktx` dependency from BuildConstants. 
- Update JacocoPlugin to report correct metrics when using roboelectric. 