### PR TITLE
Update iOS release reusable workflow - handle multi-extension repos

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -84,38 +84,38 @@ jobs:
     - name: Install XcodeGen
       run: brew install xcodegen
 
-    - name: Check Version in Podspec 
+    - name: Check version in Podspec 
       run: |
         set -eo pipefail
         echo Target version: ${{ inputs.tag }}
         make check-version VERSION=${{ inputs.tag }}
 
-    - name: Pod Repo Update
+    - name: Pod repo update
       if: ${{ inputs.create-github-release != '' }}
       run: | 
         pod repo update
 
-    - name: SPM Integration Test
+    - name: SPM integration test
       if: ${{ inputs.create-github-release != '' }}
       run: |
         set -eo pipefail
         echo SPM integration test starts:
         make test-SPM-integration
 
-    - name: Podspec File Verification
+    - name: Podspec file verification
       if: ${{ inputs.create-github-release != '' }}
       run: |
         set -eo pipefail
         echo podspec file verification starts:
         make test-podspec
         
-    - name: Build Artifacts
+    - name: Build artifacts
       if: ${{ inputs.create-github-release != '' }}
       run: |
         make archive
         make zip
 
-    - name: Create GitHub Release and Upload Assets
+    - name: Create GitHub release and upload assets
       if: ${{ inputs.create-github-release != '' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,7 +164,7 @@ jobs:
           --title "v$TAG" \
           $FILE_ARGS
 
-    - name: Publish Pods
+    - name: Publish pods
       if: ${{ inputs.pod-publish-extensions != '' }}
       env:
         POD_PUBLISH_EXTENSIONS: ${{ inputs.pod-publish-extensions }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the iOS release reusable workflow to be able to handle multi-extension repos with the main changes being:
* Ability to specify: 
    * A list of extensions to release (ex: "AEPServices, AEPCore")
    * A list of extension dependencies to release, which are not contained in the repo itself (ex: "AEPRulesEngine")
    * A list of extensions to publish to CocoaPods (ex: "AEPServices, AEPCore")

When not specifying any repos in the extensions to release, the script will still:
* Run make check-version
* Optionally publish pods, if that arg has been provided with valid values

### Example job runs
Core iOS (multi-extension): https://github.com/timkimadobe/aepsdk-core-ios/actions/runs/11471135041/job/31921556669
* NOTE: Job failure is due to missing CocoaPods secret token when running in fork (also don't want to publish as a test anyways)
* Resulting GitHub release: https://github.com/timkimadobe/aepsdk-core-ios/releases/tag/5.3.1
    * Note the assets that are also included match what was specified in the job, with the proper names
    * NOTE: the auto-generated description for the release is empty, even though the workflow is configured to create this, and this is because it relies on PR descriptions but those are in the main repo, not in the fork.

### Usage examples

Single extension repos can also use this workflow without too much friction:
```yaml
name: Release

on:
  workflow_dispatch:
    inputs:
      tag:
        description: 'The tag (version) to be released (ex: 1.2.3).'
        type: string
        required: true
        default: ''

      create-github-release:
        description: 'Create a GitHub release with uploaded artifacts. If the provided `tag` does not exist, it will be created.'
        type: boolean
        required: true
        default: true

      pod-publish-extensions:
        description: 'Publish AEPEdge to Cocoapods.'
        type: boolean
        required: true
        default: true

jobs:
  release:
    uses: adobe/aepsdk-commons/.github/workflows/ios-release.yml@gha-ios-1.0.0
    with:
      tag: ${{ github.event.inputs.tag }}
      create-github-release: ${{ github.event.inputs.create-github-release == 'true' && 'AEPEdge' || '' }}
      pod-publish-extensions: ${{ github.event.inputs.pod-publish-extensions == 'true' && 'AEPEdge' || '' }}
    secrets: inherit
```

And multi-extension repos:
```yaml
name: Release


on: 
  workflow_dispatch:
    inputs:
      tag:
        description: 'Existing tag (version) being released (ex: 5.0.1).'
        required: true
      # this is referring to releasing the extensions
      run_full_release:
        description: 'Run full release process: SPM and podspec validation, build artifacts, GH release (`false` to only check podspec version).'
        required: true
        default: true
        type: boolean

        # this section is referring to pods publishing
      release_AEPServices:
        description: 'Release AEPServices to Cocoapods (`false` to skip).'
        required: true
        default: true
        type: boolean
        
      release_AEPCore:
        description: 'Release AEPCore to Cocoapods (`false` to skip).'
        required: true
        default: true
        type: boolean
        
      release_AEPIdentity:
        description: 'Release AEPIdentity to Cocoapods (`false` to skip).'
        required: true
        default: true
        type: boolean
        
      release_AEPLifecycle:
        description: 'Release AEPLifecycle to Cocoapods (`false` to skip).'
        required: true
        default: true
        type: boolean
        
      release_AEPSignal:
        description: 'Release AEPSignal to Cocoapods (`false` to skip).'
        required: true
        default: true
        type: boolean

jobs:
  set-extensions:
    runs-on: ubuntu-latest
    outputs:
      full_release_extensions: ${{ steps.set-extensions.outputs.full_release_extensions }}
      pod_release_extensions: ${{ steps.set-extensions.outputs.pod_release_extensions }}
    steps:
      - name: Determine Extensions
        id: set-extensions
        run: |
          FULL_RELEASE_EXTENSIONS=""
          POD_RELEASE_EXTENSIONS=""

          # If run_full_release is true, add all extensions to full_release_extensions
          if [ "${{ github.event.inputs.run_full_release }}" == "true" ]; then
            FULL_RELEASE_EXTENSIONS="AEPServices,AEPCore,AEPIdentity,AEPLifecycle,AEPSignal"
          fi

          # Check each pod release input and build the pod_release_extensions string
          if [ "${{ github.event.inputs.release_AEPServices }}" == "true" ]; then
            POD_RELEASE_EXTENSIONS="${POD_RELEASE_EXTENSIONS},AEPServices"
          fi
          if [ "${{ github.event.inputs.release_AEPCore }}" == "true" ]; then
            POD_RELEASE_EXTENSIONS="${POD_RELEASE_EXTENSIONS},AEPCore"
          fi
          if [ "${{ github.event.inputs.release_AEPIdentity }}" == "true" ]; then
            POD_RELEASE_EXTENSIONS="${POD_RELEASE_EXTENSIONS},AEPIdentity"
          fi
          if [ "${{ github.event.inputs.release_AEPLifecycle }}" == "true" ]; then
            POD_RELEASE_EXTENSIONS="${POD_RELEASE_EXTENSIONS},AEPLifecycle"
          fi
          if [ "${{ github.event.inputs.release_AEPSignal }}" == "true" ]; then
            POD_RELEASE_EXTENSIONS="${POD_RELEASE_EXTENSIONS},AEPSignal"
          fi

          # Remove leading comma, if present
          POD_RELEASE_EXTENSIONS="${POD_RELEASE_EXTENSIONS#,}"

          # Output the variables to be used in the next job
          echo "full_release_extensions=$FULL_RELEASE_EXTENSIONS" >> $GITHUB_OUTPUT
          echo "pod_release_extensions=$POD_RELEASE_EXTENSIONS" >> $GITHUB_OUTPUT

  release:
    needs: set-extensions
    uses: timkimadobe/aepsdk-commons/.github/workflows/ios-release.yml@release-script-update
    with:
      tag: ${{ github.event.inputs.tag }}
      create-github-release: ${{ needs.set-extensions.outputs.full_release_extensions }}
      release-dependency-frameworks: AEPRulesEngine
      pod-publish-extensions: ${{ needs.set-extensions.outputs.pod_release_extensions }}
    secrets: inherit
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
