### PR TITLE
Update AEPGradlePlugin for Android 35

### DIFF
--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/build.gradle.kts
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/build.gradle.kts
@@ -1,9 +1,8 @@
-
-val PLUGIN_VERSION = "3.0.1"
+val PLUGIN_VERSION = "3.1.0"
 
 object Plugins {
-    const val ANDROID_GRADLE_PLUGIN_VERSION = "8.2.0"
-    const val KOTLIN_GRADLE_PLUGIN_VERSION = "1.8.20"
+    const val ANDROID_GRADLE_PLUGIN_VERSION = "8.6.0"
+    const val KOTLIN_GRADLE_PLUGIN_VERSION = "1.9.23"
     const val SPOTLESS_GRADLE_PLUGIN_VERSION = "6.12.0"
     const val DOKKA_GRADLE_PLUGIN_VERSION = "1.9.10"
     const val LICENSE_GRADLE_PLUGIN_VERSION = "0.16.1"
@@ -46,6 +45,11 @@ gradlePlugin {
     }
 }
 
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
+    archiveClassifier.set("sources")
+    from(sourceSets.main.get().allSource)
+}
+
 publishing {
     publications {
         create<MavenPublication>("pluginJitpack") {
@@ -53,6 +57,7 @@ publishing {
             artifactId = "aepsdk-gradle-plugin"
             version = PLUGIN_VERSION
             from(components["java"])
+            artifact(sourcesJar)
         }
     }
 }

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLicensePlugin.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLicensePlugin.kt
@@ -11,11 +11,11 @@
 
 package com.adobe.marketing.mobile.gradle
 
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-
 import com.hierynomus.gradle.license.tasks.LicenseFormat
 import nl.javadude.gradle.plugins.license.LicenseExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.get
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 import java.util.Calendar
@@ -29,9 +29,10 @@ class AEPLicensePlugin: Plugin<Project> {
             header = project.resources.text.fromString(BuildConstants.ADOBE_LICENSE_HEADER_RESOURCES).asFile()
             // This plugin does not understand kts extension
             mapping(mapOf("kts" to "SLASHSTAR_STYLE"))
-            extraProperties.set("year", Calendar.getInstance().get(Calendar.YEAR))
             skipExistingHeaders = true
         }
+
+        (license as? ExtensionAware)?.extraProperties?.set("year",Calendar.getInstance().get(Calendar.YEAR))
 
         // Add and maintain licence header to all project files of type XML, YAML, Properties, and Gradle
         project.tasks.register(BuildConstants.Tasks.LICENSE_FORMAT_PROJECT, LicenseFormat::class.java).configure {

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/BuildConstants.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/BuildConstants.kt
@@ -19,8 +19,8 @@ import org.gradle.api.JavaVersion
 object BuildConstants {
     object Versions {
         const val MIN_SDK_VERSION = 21
-        const val COMPILE_SDK_VERSION = 34
-        const val TARGET_SDK_VERSION = 34
+        const val COMPILE_SDK_VERSION = 35
+        const val TARGET_SDK_VERSION = 35
 
         const val VERSION_CODE = 1
         const val VERSION_NAME = "1"
@@ -33,8 +33,8 @@ object BuildConstants {
         const val KOTLIN_JVM_TARGET = "1.8"
 
 
-        const val AGP = "8.2.0"
-        const val KOTLIN = "1.8.20"
+        const val AGP = "8.6.0"
+        const val KOTLIN = "1.9.23"
         const val KOTLIN_COROUTINES = "1.6.0"
         const val KTLINT = "0.42.1"
         const val GOOGLE_JAVA_FORMAT = "1.15.0"
@@ -42,7 +42,7 @@ object BuildConstants {
         const val PRETTIER_JAVA_PLUGIN = "1.6.2"
         const val CHECKSTYLE_TOOLS = "8.36.1"
 
-        const val COMPOSE_COMPILER = "1.4.6"
+        const val COMPOSE_COMPILER = "1.5.13"
         const val COMPOSE = "1.4.3"
         const val COMPOSE_MATERIAL = "1.4.3"
         const val ANDROIDX_ACTIVITY_COMPOSE = "1.5.0"

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/JacocoPlugin.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/JacocoPlugin.kt
@@ -44,7 +44,7 @@ internal class JacocoPlugin : Plugin<Project> {
             executionData.setFrom(
                 project.fileTree(
                     mapOf(
-                        "dir" to "${project.buildDir}",
+                        "dir" to "${project.layout.buildDirectory}",
                         "includes" to listOf(BuildConstants.Reporting.UNIT_TEST_EXECUTION_RESULTS_REGEX)
                     )
                 )
@@ -69,7 +69,7 @@ internal class JacocoPlugin : Plugin<Project> {
             executionData.setFrom(
                 project.fileTree(
                     mapOf(
-                        "dir" to "${project.buildDir}",
+                        "dir" to "${project.layout.buildDirectory}",
                         "includes" to listOf(BuildConstants.Reporting.FUNCTIONAL_TEST_EXECUTION_RESULTS_REGEX)
                     )
                 )

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/JacocoPlugin.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/JacocoPlugin.kt
@@ -44,7 +44,7 @@ internal class JacocoPlugin : Plugin<Project> {
             executionData.setFrom(
                 project.fileTree(
                     mapOf(
-                        "dir" to "${project.layout.buildDirectory}",
+                        "dir" to "${project.layout.buildDirectory.asFile.get()}",
                         "includes" to listOf(BuildConstants.Reporting.UNIT_TEST_EXECUTION_RESULTS_REGEX)
                     )
                 )
@@ -69,7 +69,7 @@ internal class JacocoPlugin : Plugin<Project> {
             executionData.setFrom(
                 project.fileTree(
                     mapOf(
-                        "dir" to "${project.layout.buildDirectory}",
+                        "dir" to "${project.layout.buildDirectory.asFile.get()}",
                         "includes" to listOf(BuildConstants.Reporting.FUNCTIONAL_TEST_EXECUTION_RESULTS_REGEX)
                     )
                 )

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/ProjectExtensions.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/ProjectExtensions.kt
@@ -85,7 +85,7 @@ internal val Project.moduleAARName: String
  */
 internal val Project.moduleAARPath: String
     get() {
-        return "${buildDir}/${BuildConstants.Publishing.MODULE_AAR_OUTPUT_PATH}$moduleAARName"
+        return "${layout.buildDirectory}/${BuildConstants.Publishing.MODULE_AAR_OUTPUT_PATH}$moduleAARName"
     }
 
 // Publishing related project extensions.
@@ -169,5 +169,5 @@ internal val Project.androidJarPath: String
 
 internal val Project.intermediatePathForAEP: String
     get() {
-        return "${project.buildDir}/intermediates/javac/phoneDebug/classes/com/adobe/marketing/mobile"
+        return "${layout.buildDirectory}/intermediates/javac/phoneDebug/classes/com/adobe/marketing/mobile"
     }

--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/ProjectExtensions.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/ProjectExtensions.kt
@@ -85,7 +85,7 @@ internal val Project.moduleAARName: String
  */
 internal val Project.moduleAARPath: String
     get() {
-        return "${layout.buildDirectory}/${BuildConstants.Publishing.MODULE_AAR_OUTPUT_PATH}$moduleAARName"
+        return "${layout.buildDirectory.asFile.get()}/${BuildConstants.Publishing.MODULE_AAR_OUTPUT_PATH}$moduleAARName"
     }
 
 // Publishing related project extensions.
@@ -169,5 +169,5 @@ internal val Project.androidJarPath: String
 
 internal val Project.intermediatePathForAEP: String
     get() {
-        return "${layout.buildDirectory}/intermediates/javac/phoneDebug/classes/com/adobe/marketing/mobile"
+        return "${layout.buildDirectory.asFile.get()}/intermediates/javac/phoneDebug/classes/com/adobe/marketing/mobile"
     }

--- a/android/aepsdk-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/android/aepsdk-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/aepsdk-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/android/aepsdk-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updated the following plugins and dependencies: 
- AGP to 8.6.0 (Extensions will have to update to Gradle 8.7)
- Kotlin to 1.9.23
- Compose Compiler to 1.5.13
- Target and Compile SDK to 35

Started bundling source files with the Gradle plugin.