### PR TITLE
Update BOM build.gradle file to force selecting Android variant for Material 3

### DIFF
--- a/android/aepsdk-bom/sdk-bom/build.gradle
+++ b/android/aepsdk-bom/sdk-bom/build.gradle
@@ -28,6 +28,13 @@ android {
 
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+
+    // Since Material 3 provides multiple variants (Desktop and Android), force to use the Android variant for it
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == "androidx.compose.material3" && details.requested.name == "material3") {
+            details.useTarget("androidx.compose.material3:material3:1.2.0:releaseRuntimeElements")
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since Material 3 provides multiple variants (Desktop and Android) we need to force to use one version. It can be added in Messaging SDK's gradle file
```
  implementation("androidx.compose.material3:material3:1.2.0") {
      attributes {
          attribute(org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.attribute, objects.named("androidJvm"))
      }
  }
```
Since we already published the release, I'll add it here as a temporary fix

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
