### PR TITLE
Update Maven release to use an optional ref param for branch to release

### DIFF
--- a/.github/workflows/android-bom-release.yml
+++ b/.github/workflows/android-bom-release.yml
@@ -50,7 +50,7 @@ jobs:
         run: make -C android/aepsdk-bom bom-publish-main
 
       - name: Generate JReleaser configuration
-        uses: adobe/aepsdk-commons/.github/actions/android-setup-jreleaser-configuration@gha-android-3.4.0
+        uses: adobe/aepsdk-commons/.github/actions/android-setup-jreleaser-configuration@gha-android-3.4.1
         with:
           staging-dir: android/aepsdk-bom/sdk-bom/build/staging-deploy
   

--- a/.github/workflows/android-bom-snapshot.yml
+++ b/.github/workflows/android-bom-snapshot.yml
@@ -43,7 +43,7 @@ jobs:
         run: make -C android/aepsdk-bom bom-publish-snapshot
 
       - name: Generate JReleaser configuration
-        uses: adobe/aepsdk-commons/.github/actions/android-setup-jreleaser-configuration@gha-android-3.4.0
+        uses: adobe/aepsdk-commons/.github/actions/android-setup-jreleaser-configuration@gha-android-3.4.1
         with:
           staging-dir: android/aepsdk-bom/sdk-bom/build/staging-deploy
   

--- a/.github/workflows/android-build-and-test.yml
+++ b/.github/workflows/android-build-and-test.yml
@@ -49,12 +49,12 @@ on:
 jobs:
   validate-code:
     name: Validate Code
-    uses: adobe/aepsdk-commons/.github/workflows/android-validate-code.yml@gha-android-3.4.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-validate-code.yml@gha-android-3.4.1
   
   javadoc:
     name: Javadoc
     needs: validate-code
-    uses: adobe/aepsdk-commons/.github/workflows/android-javadoc.yml@gha-android-3.4.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-javadoc.yml@gha-android-3.4.1
     with:
       javadoc-build-path: ${{ inputs.javadoc-build-path }}
     
@@ -62,7 +62,7 @@ jobs:
     name: Unit Test
     needs: validate-code
     if: inputs.run-test-unit
-    uses: adobe/aepsdk-commons/.github/workflows/android-custom-command-build-and-test.yml@gha-android-3.4.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-custom-command-build-and-test.yml@gha-android-3.4.1
     with:
       android-api-levels: ${{ inputs.android-api-levels }}
       command: make unit-test-coverage
@@ -74,7 +74,7 @@ jobs:
     name: Functional Test
     needs: validate-code
     if: inputs.run-test-functional
-    uses: adobe/aepsdk-commons/.github/workflows/android-custom-command-build-and-test.yml@gha-android-3.4.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-custom-command-build-and-test.yml@gha-android-3.4.1
     with:
       android-api-levels: ${{ inputs.android-api-levels }}
       command: make functional-test-coverage
@@ -86,7 +86,7 @@ jobs:
     name: Integration Test
     needs: validate-code
     if: inputs.run-test-integration
-    uses: adobe/aepsdk-commons/.github/workflows/android-custom-command-build-and-test.yml@gha-android-3.4.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-custom-command-build-and-test.yml@gha-android-3.4.1
     with:
       android-api-levels: ${{ inputs.android-api-levels }}
       command: make integration-test-coverage
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       
       - name: Setup Dependencies
-        uses: adobe/aepsdk-commons/.github/actions/android-setup-dependencies-action@gha-android-3.4.0
+        uses: adobe/aepsdk-commons/.github/actions/android-setup-dependencies-action@gha-android-3.4.1
 
       - name: Assemble App
         run: make assemble-app

--- a/.github/workflows/android-custom-command-build-and-test.yml
+++ b/.github/workflows/android-custom-command-build-and-test.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
       - name: Setup Dependencies
         id: setup-dependencies
-        uses: adobe/aepsdk-commons/.github/actions/android-setup-dependencies-action@gha-android-3.4.0
+        uses: adobe/aepsdk-commons/.github/actions/android-setup-dependencies-action@gha-android-3.4.1
         with:
           android-api-level: ${{ matrix.api-level }}
 

--- a/.github/workflows/android-javadoc.yml
+++ b/.github/workflows/android-javadoc.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Setup Dependencies
         id: setup-dependencies
-        uses: adobe/aepsdk-commons/.github/actions/android-setup-dependencies-action@gha-android-3.4.0
+        uses: adobe/aepsdk-commons/.github/actions/android-setup-dependencies-action@gha-android-3.4.1
 
       - name: Javadoc
         run: make javadoc

--- a/.github/workflows/android-maven-release.yml
+++ b/.github/workflows/android-maven-release.yml
@@ -92,14 +92,22 @@ on:
         required: true
         type: string
 
+      ref:
+        description: |
+          The git reference (branch, tag, or SHA) to check out when publishing the release.
+          Defaults to 'main'.
+        required: false
+        type: string
+        default: 'main'
+
 jobs:
   validate-versions:
     name: Validate Versions
-    uses: adobe/aepsdk-commons/.github/workflows/versions.yml@gha-android-3.4.0
+    uses: adobe/aepsdk-commons/.github/workflows/versions.yml@gha-android-3.4.1
     with:
       name: ${{ inputs.version-validation-name }}
       version: ${{ github.event.inputs.tag }}
-      branch: main
+      branch: ${{ inputs.ref }}
       paths: ${{ inputs.version-validation-paths }}
       dependencies: ${{ inputs.version-validation-dependencies }}
       update: false
@@ -110,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          ref: main
+          ref: ${{ inputs.ref }}
 
       - name: Set up Java
         uses: actions/setup-java@v4.7.0
@@ -170,7 +178,7 @@ jobs:
           fi
 
       - name: Generate JReleaser configuration
-        uses: adobe/aepsdk-commons/.github/actions/android-setup-jreleaser-configuration@gha-android-3.4.0
+        uses: adobe/aepsdk-commons/.github/actions/android-setup-jreleaser-configuration@gha-android-3.4.1
         with:
           staging-dir: ${{ inputs.staging-dir }}
 

--- a/.github/workflows/android-maven-snapshot.yml
+++ b/.github/workflows/android-maven-snapshot.yml
@@ -40,10 +40,10 @@ on:
       ref:
         description: |
           The git reference (branch, tag, or SHA) to check out when publishing the snapshot.
-          Defaults to 'main'.
+          Defaults to 'staging'.
         required: false
         type: string
-        default: 'main'
+        default: 'staging'
 
       staging-dir:
         description: |
@@ -90,7 +90,7 @@ jobs:
           fi
 
       - name: Generate JReleaser configuration
-        uses: adobe/aepsdk-commons/.github/actions/android-setup-jreleaser-configuration@gha-android-3.4.0
+        uses: adobe/aepsdk-commons/.github/actions/android-setup-jreleaser-configuration@gha-android-3.4.1
         with:
           staging-dir: ${{ inputs.staging-dir }}
 

--- a/.github/workflows/android-validate-code.yml
+++ b/.github/workflows/android-validate-code.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Setup Dependencies
         id: setup-dependencies
-        uses: adobe/aepsdk-commons/.github/actions/android-setup-dependencies-action@gha-android-3.4.0
+        uses: adobe/aepsdk-commons/.github/actions/android-setup-dependencies-action@gha-android-3.4.1
 
       - name: Lint Source Code
         run: make lint

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -24,7 +24,7 @@ name: Update or Validate Versions
 # These can be passed using the `secrets: inherit` option in the caller workflow file.
 
 env:
-  WORKFLOW_TAG: gha-android-3.4.0
+  WORKFLOW_TAG: gha-android-3.4.1
 
 on:
   workflow_call:


### PR DESCRIPTION
> [!IMPORTANT]
> The Android workflow changes require a version bump from `gha-android-3.4.0` -> `gha-android-3.4.1`

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates:
* Maven release workflow to use an optional ref param for branch to release
    * `ref` used In both the version check and branch checkout
* Maven snapshot workflow to use staging as default branch instead of main Bump all android workflow versions to 3.4.1

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
