### PR TITLE
Set JRELEASER_PROJECT_NAME to project.publishArtifactId

### DIFF
--- a/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLibraryPlugin.kt
+++ b/android/aepsdk-gradle-plugin/aepsdk-gradle-plugin/src/main/kotlin/com/adobe/marketing/mobile/gradle/AEPLibraryPlugin.kt
@@ -387,12 +387,13 @@ class AEPLibraryPlugin : Plugin<Project> {
             doLast {
                 project.logger.lifecycle("configureJReleaserVariables (publishVersion): JRELEASER_PROJECT_VERSION=${project.publishVersion}")
                 project.logger.lifecycle("configureJReleaserVariables (publishGroupId): JRELEASER_PROJECT_JAVA_GROUP_ID=${project.publishGroupId}")
-                project.logger.lifecycle("configureJReleaserVariables (publishArtifactId): ${project.publishArtifactId}")
+                project.logger.lifecycle("configureJReleaserVariables (publishArtifactId): JRELEASER_PROJECT_NAME=${project.publishArtifactId}")
                 System.getenv("GITHUB_ENV")?.let { envPath ->
                         File(envPath).appendText(
                             """
                             JRELEASER_PROJECT_VERSION=${project.publishVersion}
                             JRELEASER_PROJECT_JAVA_GROUP_ID=${project.publishGroupId}
+                            JRELEASER_PROJECT_NAME=${project.publishArtifactId}
                             """.trimIndent() + "\n"
                         )
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently the uploaded bundle name is in the format:

`<namespace>-<project.name>-<project.version>-bundle.zip`
`com.adobe.marketing.mobile-aepsdk-core-android-3.5.0-bundle.zip`

But for multi-module, this ends up being the same regardless of what is being published. This PR updates to set the JReleaser var for project name to the `project.publishArtifactId`
* Ex: `core`, `lifecycle`, `assurance` etc

so that the bundle name will instead become:
`com.adobe.marketing.mobile-core-3.5.0-bundle.zip`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
